### PR TITLE
Fix complete Llama cleanup on unload

### DIFF
--- a/qwen3vl_run.py
+++ b/qwen3vl_run.py
@@ -879,8 +879,7 @@ def unload_llama_model(gccollect, debug = False, target="all"):
         if cache["llm"] is not None:
             t_start = time.perf_counter()
             try:
-                if hasattr(cache["llm"], '_ctx') and cache["llm"]._ctx is not None:
-                    cache["llm"]._ctx.close()
+                cache["llm"].close()
             except Exception:
                 pass
             del cache["llm"]


### PR DESCRIPTION
Replace the direct context close with Llama.close() when unloading a cached model. This lets llama-cpp-python release the multimodal handler, batch, context, and model through its managed cleanup path, rather than leaving the ExitStack to free the remaining native resources later.